### PR TITLE
Fix bicycle model implementation issues and add Ackermann steering

### DIFF
--- a/Assets/Plugins/TrafficSimulation/include/bicycle_model.h
+++ b/Assets/Plugins/TrafficSimulation/include/bicycle_model.h
@@ -221,4 +221,90 @@ public:
     double normalizeAngle(double angle) const;
 };
 
+/**
+ * @class AckermannModel
+ * @brief Extended bicycle model implementing Ackermann steering geometry.
+ *
+ * This class extends the basic bicycle model to include proper Ackermann steering
+ * geometry, accounting for the track width and differential wheel steering angles.
+ * This provides more accurate modeling for vehicles with front-wheel steering systems.
+ *
+ * Key Features:
+ * - Calculates individual wheel steering angles based on Ackermann geometry
+ * - Accounts for track width in steering calculations
+ * - Maintains compatibility with bicycle model interface
+ * - Provides foundation for multi-wheel dynamics simulation
+ */
+class AckermannModel : public BicycleModel {
+private:
+    double track_width;  ///< Distance between left and right wheels (m)
+
+public:
+    /**
+     * @brief Constructor for AckermannModel with Ackermann-specific parameters.
+     * 
+     * @param wb Distance between front and rear axles (m)
+     * @param tw Track width - distance between left and right wheels (m)  
+     * @param m Vehicle mass (kg)
+     * @param inertia Yaw moment of inertia (kg*m^2)
+     * @param front_length Distance from CG to front axle (m)
+     * @param rear_length Distance from CG to rear axle (m)
+     * @param front_stiffness Front cornering stiffness (N/rad)
+     * @param rear_stiffness Rear cornering stiffness (N/rad)
+     */
+    AckermannModel(double wb = 2.7, double tw = 1.6, double m = 1500.0, double inertia = 2500.0,
+                   double front_length = 1.35, double rear_length = 1.35,
+                   double front_stiffness = 50000.0, double rear_stiffness = 50000.0)
+        : BicycleModel(wb, m, inertia, front_length, rear_length, front_stiffness, rear_stiffness),
+          track_width(tw) {}
+
+    /**
+     * @brief Calculates individual wheel steering angles based on Ackermann geometry.
+     * 
+     * This method computes the inner and outer wheel steering angles required to
+     * satisfy Ackermann steering geometry, where all wheels follow circular paths
+     * with the same center point. This eliminates tire scrubbing during turns.
+     * 
+     * For a given center steering angle δ:
+     * - Inner wheel: δ_inner = atan(L / (R - T/2))
+     * - Outer wheel: δ_outer = atan(L / (R + T/2))
+     * 
+     * Where L is wheelbase, R is turning radius, and T is track width.
+     * 
+     * @param center_steering_angle The equivalent single-wheel steering angle (rad)
+     * @return std::pair<double, double> Inner and outer wheel angles (rad)
+     * @throws std::invalid_argument if steering angle results in impossible geometry
+     */
+    std::pair<double, double> calculateWheelAngles(double center_steering_angle) const;
+
+    /**
+     * @brief Updates vehicle state using Ackermann steering geometry.
+     * 
+     * This method extends the base kinematic model to account for the differential
+     * steering angles calculated from Ackermann geometry. It provides more accurate
+     * vehicle dynamics for applications requiring precise steering simulation.
+     * 
+     * @param vehicle Current vehicle state
+     * @param center_steering_angle Desired center steering angle (rad)
+     * @param velocity Vehicle velocity (m/s)
+     * @param dt Time step (s)
+     * @return Updated vehicle state
+     */
+    Vehicle updateAckermannState(const Vehicle& vehicle, double center_steering_angle, 
+                                double velocity, double dt) const;
+
+    /**
+     * @brief Gets the track width of the vehicle.
+     * @return Track width in meters
+     */
+    double getTrackWidth() const { return track_width; }
+
+    /**
+     * @brief Sets the track width of the vehicle.
+     * @param tw New track width in meters (must be positive)
+     * @throws std::invalid_argument if track width is not positive
+     */
+    void setTrackWidth(double tw);
+};
+
 #endif // BICYCLE_MODEL_H

--- a/Assets/Plugins/TrafficSimulation/src/bicycle_model.cpp
+++ b/Assets/Plugins/TrafficSimulation/src/bicycle_model.cpp
@@ -12,7 +12,7 @@ double BicycleModel::calculateSteadyStateYawRate(double steering_angle_rad, doub
     if (wheelbase <= 0.0) {
         throw std::invalid_argument("Wheelbase must be positive.");
     }
-    return (velocity * steering_angle_rad) / wheelbase;
+    return (velocity * tan(steering_angle_rad)) / wheelbase;
 }
 
 // Normalize angle to [-π, π]
@@ -220,12 +220,14 @@ Vehicle BicycleModel::updateCoupledState(
     const double F_yr = computeNonlinearTireForce(Cr, F_normal_rear, alpha_r, a_x);
 
     // Update longitudinal and lateral accelerations
-    const double ax = (F_yf * cos(steering_angle_rad) - F_drag) / mass;
-    const double ay = (F_yf + F_yr) / mass;
+    const double ax = (F_yf * sin(steering_angle_rad)) / mass;  // Lateral acceleration from front tire forces
+    const double ay = (F_yf * cos(steering_angle_rad) + F_yr - F_drag) / mass;  // Longitudinal acceleration
 
-    // Update velocities and yaw rate
-    next_state.setVx(next_state.getVx() + ax * dt - current_state.getYawRate() * current_state.getVz());
-    next_state.setVz(next_state.getVz() + ay * dt + current_state.getYawRate() * current_state.getVx());
+    // Update velocities with proper centrifugal force coupling
+    // For body-fixed coordinates: v_dot = a + ω × v
+    const double omega_z = current_state.getYawRate();
+    next_state.setVx(current_state.getVx() + (ax - omega_z * current_state.getVz()) * dt);
+    next_state.setVz(current_state.getVz() + (ay + omega_z * current_state.getVx()) * dt);
     next_state.setYawRate(next_state.getYawRate() +  (F_yf * lf - F_yr * lr) / Iz * dt);
 
     // Update position and heading
@@ -255,4 +257,62 @@ double BicycleModel::computeNonlinearTireForce(
     const double Fy = D * sin(C * atan(term - E * (term - atan(term))));
 
     return Fy;
+}
+
+// AckermannModel implementation
+std::pair<double, double> AckermannModel::calculateWheelAngles(double center_steering_angle) const {
+    if (std::abs(center_steering_angle) < 1e-8) {
+        // Straight driving - both wheels have zero angle
+        return {0.0, 0.0};
+    }
+    
+    // Calculate turning radius from center steering angle
+    // For small angles: R ≈ L/δ, for exact: R = L/tan(δ)
+    const double turning_radius = wheelbase / std::tan(center_steering_angle);
+    
+    // Check for impossible geometry (turning radius too small)
+    if (std::abs(turning_radius) < track_width / 2.0) {
+        throw std::invalid_argument("Turning radius too small for vehicle track width");
+    }
+    
+    // Calculate wheel angles using Ackermann geometry
+    // Inner wheel (tighter turn): δ_inner = atan(L / (R - T/2))
+    // Outer wheel (wider turn): δ_outer = atan(L / (R + T/2))
+    
+    double inner_angle, outer_angle;
+    
+    if (center_steering_angle > 0) {  // Left turn
+        inner_angle = std::atan(wheelbase / (turning_radius - track_width / 2.0));
+        outer_angle = std::atan(wheelbase / (turning_radius + track_width / 2.0));
+    } else {  // Right turn
+        inner_angle = std::atan(wheelbase / (-turning_radius - track_width / 2.0));
+        outer_angle = std::atan(wheelbase / (-turning_radius + track_width / 2.0));
+    }
+    
+    return {inner_angle, outer_angle};
+}
+
+Vehicle AckermannModel::updateAckermannState(const Vehicle& vehicle, double center_steering_angle,
+                                           double velocity, double dt) const {
+    if (dt <= 0.0) {
+        throw std::invalid_argument("Time step (dt) must be positive.");
+    }
+    
+    // Calculate individual wheel angles
+    auto [inner_angle, outer_angle] = calculateWheelAngles(center_steering_angle);
+    
+    // Use average wheel angle for bicycle model approximation
+    // This maintains compatibility with the existing bicycle model framework
+    // while incorporating Ackermann geometry effects
+    const double effective_steering_angle = (inner_angle + outer_angle) / 2.0;
+    
+    // Apply standard kinematic bicycle model with effective steering angle
+    return updateKinematicState(vehicle, effective_steering_angle, velocity, dt);
+}
+
+void AckermannModel::setTrackWidth(double tw) {
+    if (tw <= 0.0) {
+        throw std::invalid_argument("Track width must be positive.");
+    }
+    track_width = tw;
 }

--- a/Assets/Plugins/TrafficSimulation/src/traffic.cpp
+++ b/Assets/Plugins/TrafficSimulation/src/traffic.cpp
@@ -230,8 +230,8 @@ void Traffic::applyActions(Vehicle& vehicle, int high_level_action, const std::v
     vehicle.setYaw(next_state.getYaw());
     vehicle.setSteering(steering);
 
-    vehicle.setVx(next_state.getVx()); // Longitudional speed
-    vehicle.setVz(next_state.getVz()); // lateral speed
+    vehicle.setVx(next_state.getVx()); // Lateral speed
+    vehicle.setVz(next_state.getVz()); // Longitudinal speed
 }
 
 /**


### PR DESCRIPTION
1. Fix steady-state yaw rate calculation to use tan(δ) instead of δ
2. Correct velocity comments in traffic.cpp (Vx=lateral, Vz=longitudinal)
3. Fix centrifugal force coupling in updateCoupledState method
4. Add AckermannModel class with proper Ackermann steering geometry
5. Implement individual wheel angle calculations for Ackermann steering

Addresses issues identified in kinematic bicycle model review.

🤖 Generated with [Claude Code](https://claude.ai/code)