### PR TITLE
Fix C++ compilation errors for PyPI package build

### DIFF
--- a/Assets/Plugins/TrafficSimulation/include/bicycle_model.h
+++ b/Assets/Plugins/TrafficSimulation/include/bicycle_model.h
@@ -45,7 +45,7 @@
  */
 
 class BicycleModel {
-private:
+protected:
     // Vehicle parameters
     double wheelbase;    ///< Distance between the front and rear axles (m)
     double mass;         ///< Vehicle mass (kg)

--- a/Assets/Plugins/TrafficSimulation/include/traffic.h
+++ b/Assets/Plugins/TrafficSimulation/include/traffic.h
@@ -116,6 +116,12 @@ public:
      */
     void setMaxVehicleSpeed(float max_speed);
 
+    /**
+     * @brief Getter for the random seed.
+     * @return The seed value used for random generation.
+     */
+    unsigned int getSeed() const;
+
 
 private:
     int num_agents; ///< Number of agents in the simulation.

--- a/Assets/Plugins/TrafficSimulation/src/bicycle_model.cpp
+++ b/Assets/Plugins/TrafficSimulation/src/bicycle_model.cpp
@@ -299,7 +299,9 @@ Vehicle AckermannModel::updateAckermannState(const Vehicle& vehicle, double cent
     }
     
     // Calculate individual wheel angles
-    auto [inner_angle, outer_angle] = calculateWheelAngles(center_steering_angle);
+    const std::pair<double, double> wheel_angles = calculateWheelAngles(center_steering_angle);
+    const double inner_angle = wheel_angles.first;
+    const double outer_angle = wheel_angles.second;
     
     // Use average wheel angle for bicycle model approximation
     // This maintains compatibility with the existing bicycle model framework

--- a/Assets/Plugins/TrafficSimulation/src/traffic.cpp
+++ b/Assets/Plugins/TrafficSimulation/src/traffic.cpp
@@ -271,6 +271,14 @@ void Traffic::setMaxVehicleSpeed(float max_speed) {
 }
 
 /**
+* @brief Getter for the random seed.
+* @return The seed value used for random generation.
+*/
+unsigned int Traffic::getSeed() const {
+    return seed;
+}
+
+/**
  * @brief Generates a random float within a specified range.
  * @param a Lower bound of the range.
  * @param b Upper bound of the range.


### PR DESCRIPTION
Fixes C++ compilation errors preventing PyPI package build

- Fix private member access errors in bicycle_model.cpp
- Replace C++17 structured bindings with C++14-compatible code
- Add getSeed() method to suppress unused field warning

Generated with [Claude Code](https://claude.ai/code)