### PR TITLE
Update to v0.6.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ReplicantDriveSim
-version = 0.5.9
+version = 0.6.0
 description = A Unity Traffic Simulation
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Ran,
python examples/runner.py
replicantdrivesim (version 0.5.9)
2025-09-10 04:21:12,283 INFO worker.py:1841 -- Started a local Ray instance.
Checked: '/Users/christiancontrerascampana/anaconda3/envs/mlagents_py3p10/lib/python3.10/site-packages/replicantdrivesim/Builds/StandaloneOSX/libReplicantDriveSim.app' is a directory.
(pid=65205) replicantdrivesim (version 0.5.9)
(UnityEnvResource pid=65205) Set offRoadPenalty to -0.5
(UnityEnvResource pid=65205) Set onRoadReward to 0.01
(UnityEnvResource pid=65205) Set collisionWithOtherAgentPenalty to -1.0
(UnityEnvResource pid=65205) Set medianCrossingPenalty to -1.0
(UnityEnvResource pid=65205) [UnityMemory] Configuration Parameters - Can be set up in boot.config
(UnityEnvResource pid=65205) "memorysetup-bucket-allocator-granularity=16"
(UnityEnvResource pid=65205) "memorysetup-bucket-allocator-bucket-count=8"
(UnityEnvResource pid=65205) "memorysetup-bucket-allocator-block-size=4194304"
(UnityEnvResource pid=65205) "memorysetup-bucket-allocator-block-count=1"
(UnityEnvResource pid=65205) "memorysetup-main-allocator-block-size=16777216"
(UnityEnvResource pid=65205) "memorysetup-thread-allocator-block-size=16777216"
(UnityEnvResource pid=65205) "memorysetup-gfx-main-allocator-block-size=16777216"
(UnityEnvResource pid=65205) "memorysetup-gfx-thread-allocator-block-size=16777216"
(UnityEnvResource pid=65205) "memorysetup-cache-allocator-block-size=4194304"
(UnityEnvResource pid=65205) "memorysetup-typetree-allocator-block-size=2097152"
(UnityEnvResource pid=65205) "memorysetup-profiler-bucket-allocator-granularity=16"
(UnityEnvResource pid=65205) "memorysetup-profiler-bucket-allocator-bucket-count=8"
(UnityEnvResource pid=65205) "memorysetup-profiler-bucket-allocator-block-size=4194304"
(UnityEnvResource pid=65205) "memorysetup-profiler-bucket-allocator-block-count=1"
(UnityEnvResource pid=65205) "memorysetup-profiler-allocator-block-size=16777216"
(UnityEnvResource pid=65205) "memorysetup-profiler-editor-allocator-block-size=1048576"
(UnityEnvResource pid=65205) "memorysetup-temp-allocator-size-main=4194304"
(UnityEnvResource pid=65205) "memorysetup-job-temp-allocator-block-size=2097152"
(UnityEnvResource pid=65205) "memorysetup-job-temp-allocator-block-size-background=1048576"
(UnityEnvResource pid=65205) "memorysetup-job-temp-allocator-reduction-small-platforms=262144"
(UnityEnvResource pid=65205) "memorysetup-allocator-temp-initial-block-size-main=262144"
(UnityEnvResource pid=65205) "memorysetup-allocator-temp-initial-block-size-worker=262144"
(UnityEnvResource pid=65205) "memorysetup-temp-allocator-size-background-worker=32768"
(UnityEnvResource pid=65205) "memorysetup-temp-allocator-size-job-worker=262144"
(UnityEnvResource pid=65205) "memorysetup-temp-allocator-size-preload-manager=262144"
(UnityEnvResource pid=65205) "memorysetup-temp-allocator-size-nav-mesh-worker=65536"
(UnityEnvResource pid=65205) "memorysetup-temp-allocator-size-audio-worker=65536"
(UnityEnvResource pid=65205) "memorysetup-temp-allocator-size-cloud-worker=32768"
(UnityEnvResource pid=65205) "memorysetup-temp-allocator-size-gfx=262144"
Initializing with 1 active agents
API Version: 1.5.0
Behavior specs: ['TrafficAgent?team=0']
Initialized with behavior name: TrafficAgent?team=0
Action spec - Continuous: 3, Discrete: (5,)
Initial number of agents: 1
Continuous action size: 3
Discrete action branches: (5,)
/Users/christiancontrerascampana/anaconda3/envs/mlagents_py3p10/lib/python3.10/site-packages/gymnasium/spaces/box.py:235: UserWarning: WARN: Box low's precision lowered by casting to float32, current low.dtype=float64
gym.logger.warn(
/Users/christiancontrerascampana/anaconda3/envs/mlagents_py3p10/lib/python3.10/site-packages/gymnasium/spaces/box.py:305: UserWarning: WARN: Box high's precision lowered by casting to float32, current high.dtype=float64
gym.logger.warn(
API Version: 1.5.0
An error occurred while setting up or running the environment: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'

Where is the error,
An error occurred while setting up or running the environment: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'

stemming from and how to fix it.

Additional context, I ran,

python script.py
Python version: 3.10.12 (main, Jul 5 2023, 15:02:25) [Clang 14.0.6 ]
Python executable: /Users/christiancontrerascampana/anaconda3/envs/mlagents_py3p10/bin/python
NumPy imports successfully

where script.py is
import sys
print(f"Python version: {sys.version}")
print(f"Python executable: {sys.executable}")

Check if other pybind11 packages work
try:
import numpy # Usually has pybind11 bindings
print("NumPy imports successfully")
except ImportError as e:
print(f"NumPy import error: {e}")

