### PR TITLE
Fix PyPI source distribution filename for PEP 625 compliance

### DIFF
--- a/replicantdrivesim/__init__.py
+++ b/replicantdrivesim/__init__.py
@@ -14,7 +14,7 @@ try:
     from importlib.metadata import PackageNotFoundError, version
 
     try:
-        __version__ = version("ReplicantDriveSim")
+        __version__ = version("replicantdrivesim")
     except PackageNotFoundError:
         # package is not installed
         __version__ = "unknown"
@@ -24,7 +24,7 @@ except ImportError:
         from importlib_metadata import PackageNotFoundError, version
 
         try:
-            __version__ = version("ReplicantDriveSim")
+            __version__ = version("replicantdrivesim")
         except PackageNotFoundError:
             __version__ = "unknown"
     except ImportError:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = ReplicantDriveSim
+name = replicantdrivesim
 version = 0.6.0
 description = A Unity Traffic Simulation
 long_description = file: README.md


### PR DESCRIPTION
This PR fixes the PyPI source distribution filename to comply with PEP 625.

## Changes
- Normalize project name from `ReplicantDriveSim` to `replicantdrivesim` in setup.cfg
- Update package name references in __init__.py for version lookup
- Ensures source distribution filename will be `replicantdrivesim-0.6.0.tar.gz`

Fixes #168

Generated with [Claude Code](https://claude.ai/code)