### PR TITLE
Fix NoneType error in environment initialization

### DIFF
--- a/replicantdrivesim/envs/environment.py
+++ b/replicantdrivesim/envs/environment.py
@@ -142,7 +142,9 @@ class CustomUnityMultiAgentEnv(MultiAgentEnv):
         print(f"API Version: {self.api_version}")
 
         # Get the simulation time step (i.e., frames per second)
-        self.fps = int(ray.get(self.unity_env_handle.get_field_value.remote("FramesPerSecond")).get("FramesPerSecond", 25))
+        fps_result = ray.get(self.unity_env_handle.get_field_value.remote("FramesPerSecond"))
+        fps_value = fps_result.get("FramesPerSecond")
+        self.fps = int(fps_value if fps_value is not None else 25)
 
     @property
     def single_agent_obs_space(self):


### PR DESCRIPTION
This PR fixes the environment initialization error reported in #170.

## Problem
The `int() argument must be a string, a bytes-like object or a real number, not 'NoneType'` error occurred when Unity hadn't sent the FramesPerSecond value yet.

## Solution
Fixed by explicitly checking if the retrieved field value is None before converting to int, using a fallback value of 25 when needed.

## Testing
The fix ensures proper fallback handling and maintains compatibility with existing functionality.

Fixes #170

Generated with [Claude Code](https://claude.ai/code)